### PR TITLE
AUT-6-AMD-desktop-IO-stress-test

### DIFF
--- a/amd_desktop/amd64_stress.py
+++ b/amd_desktop/amd64_stress.py
@@ -9,7 +9,31 @@ from typing import List
 logger = logging.getLogger(__name__)
 
 class AMD64MultiPathStress(object):
+    """
+    Class to perform multi-path I/O stress testing on AMD64 systems.
+
+    This class uses the `Win10Interface` to execute I/O operations and analyze
+    the performance under stress conditions by running disk speed tests with
+    various parameters.
+
+    Attributes:
+        write_pattern (str): The write pattern to be used in the stress test.
+        duration (int): Duration of the stress test in seconds.
+        io_paths (List[str]): List of I/O paths (drive letters) where the stress
+                              test will be executed.
+        api (Win10Interface): An instance of the Win10Interface class used to
+                              execute commands on the Windows 10 environment.
+    """
     def __init__(self, write_pattern, duration, io_paths: List):
+        """
+        Initializes the AMD64MultiPathStress class with test parameters.
+
+        Args:
+            write_pattern (str): The write pattern to be used in the stress test.
+            duration (int): Duration of the stress test in seconds.
+            io_paths (List[str]): List of I/O paths (drive letters) where the
+                                  stress test will be executed.
+        """
         self.write_pattern = write_pattern
         self.duration = duration
         self.io_paths = io_paths
@@ -17,19 +41,46 @@ class AMD64MultiPathStress(object):
 
     def run_io_operation(self, thread, iodepth, block_size, random_size,
             write_pattern, duration):
+        """
+        Runs an I/O operation using the specified parameters and returns the 
+        IOPS and bandwidth for both read and write operations.
 
-        logger.debug(f'thread = {thread}')
-        logger.debug(f'iodepth = {iodepth}')
-        logger.debug(f'block_size = {block_size}')
-        logger.debug(f'random_size = {random_size}')
-        logger.debug(f'write_pattern = {write_pattern}')
-        logger.debug(f'duration = {duration}')
+        Args:
+            thread (int): Number of threads to use in the I/O operation.
+            iodepth (int): I/O depth (queue depth) for the operation.
+            block_size (str): Block size for the I/O operation (e.g., '4K').
+            random_size (str): Random size for the I/O operation.
+            write_pattern (str): Write pattern percentage (e.g., '100' for write only).
+            duration (int): Duration of the test in seconds.
+
+        Returns:
+            tuple: A tuple containing four float values:
+                   (read_bw, read_iops, write_bw, write_iops)
+                   where:
+                   - read_bw (float): Read bandwidth.
+                   - read_iops (float): Read IOPS.
+                   - write_bw (float): Write bandwidth.
+                   - write_iops (float): Write IOPS.
+
+        Raises:
+            RuntimeError: If no output is returned from the I/O command.
+            Exception: If any other error occurs during the I/O operation,
+                       it is logged and then re-raised to be handled by the
+                       caller.
+        """
+        logger.info(f'thread = {thread}')
+        logger.info(f'iodepth = {iodepth}')
+        logger.info(f'block_size = {block_size}')
+        logger.info(f'random_size = {random_size}')
+        logger.info(f'write_pattern = {write_pattern}')
+        logger.info(f'duration = {duration}')
         logger.debug(f'self._io_file = {self.io_paths}')
         
         read_iops = read_bw = write_iops = write_bw = None
-        list_io_path = [f'{drive_letter}:\\IO.dat' for drive_letter, _ in self.io_paths]
-        print(f'list_io_path = {list_io_path}')
-        print(f'{" ".join(list_io_path)}')
+        list_io_path = [f'{drive_letter}:\\IO.dat' for drive_letter,
+                        _ in self.io_paths]
+        logger.info(f'_io_file = {" ".join(list_io_path)}')
+
         try:
             str_command = (f'diskspd -c1 -t{thread}'
             f' -o{iodepth} -b{block_size} -r{random_size}'
@@ -45,7 +96,6 @@ class AMD64MultiPathStress(object):
                 re.S)
             write_io_section = re.search(r'Write IO(.*?)(\n\n|\Z)',
                 str_output, re.S)
-            # logger.debug(f'write_io_section = {write_io_section.group(1)}')
 
             if read_io_section:
                 read_io_text = read_io_section.group(1)
@@ -77,5 +127,7 @@ class AMD64MultiPathStress(object):
         except Exception as e:
             logger.error(f"Error occurred in run_io_operation: {e}")
             raise
+
         finally:
-            return float(read_bw), float(read_iops), float(write_bw), float(write_iops)
+            return (float(read_bw), float(read_iops), float(write_bw),
+                    float(write_iops))

--- a/config/amd64_nvme.json
+++ b/config/amd64_nvme.json
@@ -31,9 +31,19 @@
         "unsafe_shutdowns": 624
     },
     "Disk Information": {
-        "Number": 2,
+        "Number": 12,
         "SerialNumber": "0050_43C5_0E00_0001.",
-        "Volume": "D",
-        "Size": "931.43 GB"
+        "D": "40 GB",
+        "F": "40 GB",
+        "G": "40 GB",
+        "H": "40 GB",
+        "I": "40 GB",
+        "J": "40 GB",
+        "K": "40 GB",
+        "L": "40 GB",
+        "M": "40 GB",
+        "N": "40 GB",
+        "O": "40 GB",
+        "P": "40 GB"
     }
 }

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,9 +13,10 @@ log_date_format = %Y-%m-%d %H:%M:%S
 ; addopts = -s -x -vv --capture=no
 addopts = -s -x -vv
     --capture=no
+    --cov=tests/
     ; --cov=amd_desktop/
     ; --cov=tests/test_unit
-    --cov=tests/test_raspberry
+    ; --cov=tests/test_raspberr
     --json-report
     --json-report-file=.report.json
     ; --testmon

--- a/tests/test_amd_desktop/conftest.py
+++ b/tests/test_amd_desktop/conftest.py
@@ -10,10 +10,11 @@ from amd_desktop.win10_interface import Win10Interface as win10
 from unit.mongodb import MongoDB as mdb
 from unit.system_under_testing import RaspberryPi as rpi
 
-logging.getLogger('amd_desktop.amd64_nvme').setLevel(logging.DEBUG)
+logging.getLogger('amd_desktop.amd64_nvme').setLevel(logging.INFO)
 logging.getLogger('amd_desktop.win10_interface').setLevel(logging.CRITICAL)
 logging.getLogger('amd_desktop.amd64_perf').setLevel(logging.CRITICAL)
-logging.getLogger('amd_desktop.amd64_ping').setLevel(logging.CRITICAL)
+logging.getLogger('amd_desktop.amd64_ping').setLevel(logging.INFO)
+logging.getLogger('amd_desktop.amd64_stress').setLevel(logging.INFO)
 
 paramiko.util.log_to_file("paramiko.log", level=logging.CRITICAL)
 
@@ -44,7 +45,7 @@ def test_open_uart(drone):
     print('\n\033[32m================== Setup UART ==================\033[0m')
     yield drone.open_uart()
     print('\n\033[32m================ Teardown UART =================\033[0m')
-#     drone.close_uart()
+    drone.close_uart()
 
 @pytest.fixture(scope="function", autouse=True)
 def target_perf():

--- a/tests/test_amd_desktop/conftest.py
+++ b/tests/test_amd_desktop/conftest.py
@@ -10,7 +10,7 @@ from amd_desktop.win10_interface import Win10Interface as win10
 from unit.mongodb import MongoDB as mdb
 from unit.system_under_testing import RaspberryPi as rpi
 
-logging.getLogger('amd_desktop.amd64_nvme').setLevel(logging.CRITICAL)
+logging.getLogger('amd_desktop.amd64_nvme').setLevel(logging.DEBUG)
 logging.getLogger('amd_desktop.win10_interface').setLevel(logging.CRITICAL)
 logging.getLogger('amd_desktop.amd64_perf').setLevel(logging.CRITICAL)
 logging.getLogger('amd_desktop.amd64_ping').setLevel(logging.CRITICAL)

--- a/tests/test_amd_desktop/test_amd64_coldboot.py
+++ b/tests/test_amd_desktop/test_amd64_coldboot.py
@@ -1,0 +1,10 @@
+# Contents of test_amd64_coldboot.py
+'''Copyright (c) 2024 Jaron Cheng'''
+import logging
+
+logger = logging.getLogger(__name__)
+logging.getLogger(__name__).setLevel(logging.INFO)
+
+class TestAMD64ColdBoot(object):
+    pass
+

--- a/tests/test_amd_desktop/test_amd64_nvme.py
+++ b/tests/test_amd_desktop/test_amd64_nvme.py
@@ -93,8 +93,6 @@ class TestAMD64NVMe(object):
 
     @pytest.mark.parametrize('amd64_nvm', AMD64_NVM)
     def test_get_volume(self, target_system, amd64_nvm):
-        # logger.info(f'Volume = {target_system.volume}')
-        # logger.info(f'Size = {target_system.size}')
         logger.info(f'{target_system.disk_info[0][0]} = '
               f'{target_system.disk_info[0][1]}')
         logger.info(f'{target_system.disk_info[1][0]} = '
@@ -147,30 +145,4 @@ class TestAMD64NVMe(object):
         # assert target_system.size == \
         #     amd64_nvm['Disk Information']["Size"]
  
-    # @pytest.mark.repeat(3)
-    # @pytest.mark.parametrize('test_pattern', TEST_PATTERN)
-    # def test_run_io_operation(self, target_system, test_pattern):
-    #     read_bw, read_iops, write_bw, write_iops = \
-    #         target_system.run_io_operation(
-    #             test_pattern["Thread"],
-    #             test_pattern["IO Depth"],
-    #             test_pattern["Block Size"],
-    #             test_pattern["Random Size"],
-    #             test_pattern["Write Pattern"],
-    #             test_pattern["Duration"],
-    #             test_pattern["Test File"]
-    #     )
-    #     logger.info(f'read_bw = {read_bw}')
-    #     logger.info(f'read_iops = {read_iops}')
-    #     logger.info(f'write_bw = {write_bw}')
-    #     logger.info(f'write_iops = {write_iops}')
-        
-    #     assert read_bw >= \
-    #         test_pattern["Read IO"]["BW"] * test_pattern["CR"]
-    #     assert read_iops >= \
-    #         test_pattern["Read IO"]["IOPS"] * test_pattern["CR"]
-    #     assert write_bw >= \
-    #         test_pattern["Write IO"]["BW"] * test_pattern["CR"]
-    #     assert write_iops >= \
-    #         test_pattern["Write IO"]["IOPS"] * test_pattern["CR"]
         

--- a/tests/test_amd_desktop/test_amd64_nvme.py
+++ b/tests/test_amd_desktop/test_amd64_nvme.py
@@ -93,12 +93,59 @@ class TestAMD64NVMe(object):
 
     @pytest.mark.parametrize('amd64_nvm', AMD64_NVM)
     def test_get_volume(self, target_system, amd64_nvm):
-        logger.info(f'Volume = {target_system.volume}')
-        logger.info(f'Size = {target_system.size}')
-        assert target_system.volume == \
-            amd64_nvm['Disk Information']["Volume"]
-        assert target_system.size == \
-            amd64_nvm['Disk Information']["Size"]
+        # logger.info(f'Volume = {target_system.volume}')
+        # logger.info(f'Size = {target_system.size}')
+        logger.info(f'{target_system.disk_info[0][0]} = '
+              f'{target_system.disk_info[0][1]}')
+        logger.info(f'{target_system.disk_info[1][0]} = '
+              f'{target_system.disk_info[1][1]}')
+        logger.info(f'{target_system.disk_info[2][0]} = '
+              f'{target_system.disk_info[2][1]}')
+        logger.info(f'{target_system.disk_info[3][0]} = '
+              f'{target_system.disk_info[3][1]}')
+        logger.info(f'{target_system.disk_info[4][0]} = '
+              f'{target_system.disk_info[4][1]}')
+        logger.info(f'{target_system.disk_info[5][0]} = '
+              f'{target_system.disk_info[5][1]}')
+        logger.info(f'{target_system.disk_info[6][0]} = '
+              f'{target_system.disk_info[6][1]}')
+        logger.info(f'{target_system.disk_info[7][0]} = '
+              f'{target_system.disk_info[7][1]}')
+        logger.info(f'{target_system.disk_info[8][0]} = '
+              f'{target_system.disk_info[8][1]}')
+        logger.info(f'{target_system.disk_info[9][0]} = '
+              f'{target_system.disk_info[9][1]}')
+        logger.info(f'{target_system.disk_info[10][0]} = '
+              f'{target_system.disk_info[10][1]}')
+        logger.info(f'{target_system.disk_info[11][0]} = '
+              f'{target_system.disk_info[11][1]}')
+        
+        assert target_system.disk_info[0][1] == \
+            amd64_nvm['Disk Information']["D"]
+        assert target_system.disk_info[1][1] == \
+            amd64_nvm['Disk Information']["F"]
+        assert target_system.disk_info[2][1] == \
+            amd64_nvm['Disk Information']["G"]
+        assert target_system.disk_info[3][1] == \
+            amd64_nvm['Disk Information']["H"]
+        assert target_system.disk_info[4][1] == \
+            amd64_nvm['Disk Information']["I"]
+        assert target_system.disk_info[5][1] == \
+            amd64_nvm['Disk Information']["J"]
+        assert target_system.disk_info[6][1] == \
+            amd64_nvm['Disk Information']["K"]
+        assert target_system.disk_info[7][1] == \
+            amd64_nvm['Disk Information']["L"]
+        assert target_system.disk_info[8][1] == \
+            amd64_nvm['Disk Information']["M"]
+        assert target_system.disk_info[9][1] == \
+            amd64_nvm['Disk Information']["N"]
+        assert target_system.disk_info[10][1] == \
+            amd64_nvm['Disk Information']["O"]
+        assert target_system.disk_info[11][1] == \
+            amd64_nvm['Disk Information']["P"]
+        # assert target_system.size == \
+        #     amd64_nvm['Disk Information']["Size"]
  
     # @pytest.mark.repeat(3)
     # @pytest.mark.parametrize('test_pattern', TEST_PATTERN)

--- a/tests/test_amd_desktop/test_amd64_perf.py
+++ b/tests/test_amd_desktop/test_amd64_perf.py
@@ -21,7 +21,7 @@ class TestRandomReadWrite(nvm):
     @pytest.mark.parametrize('write_pattern', [0, 100])
     def test_run_io_operation(self, target_perf, write_pattern, io_depth, my_mdb):
         read_bw, read_iops, write_bw, write_iops = target_perf.run_io_operation(
-            1, io_depth, '4k', '4k', write_pattern, 120)
+            2, io_depth, '4k', '4k', write_pattern, 120)
         logger.info(f'random_read_bw = {read_bw}')
         logger.info(f'random_read_iops = {read_iops}')
         logger.info(f'random_write_bw = {write_bw}')
@@ -54,7 +54,7 @@ class TestSequentialReadWrite(nvm):
     def test_run_io_operation(self, target_perf, write_pattern, io_depth,
         my_mdb):
         read_bw, read_iops, write_bw, write_iops = \
-            target_perf.run_io_operation(1, io_depth, '4k', None,
+            target_perf.run_io_operation(2, io_depth, '4k', None,
                 write_pattern, 10)
         logger.info(f'sequential_read_bw = {read_bw}')
         logger.info(f'sequential_read_iops = {read_iops}')
@@ -93,7 +93,7 @@ class TestRampTimeReadWrite(nvm):
     def test_run_io_operation(self, target_perf, write_pattern, ramp_times,
         my_mdb):
         read_bw, read_iops, write_bw, write_iops = \
-            target_perf.run_io_operation(1, 4, '4k', '4k',
+            target_perf.run_io_operation(2, 4, '4k', '4k',
                 write_pattern, ramp_times)
         logger.info(f'ramp_read_bw = {read_bw}')
         logger.info(f'ramp_read_iops = {read_iops}')

--- a/tests/test_amd_desktop/test_amd64_perf.py
+++ b/tests/test_amd_desktop/test_amd64_perf.py
@@ -6,7 +6,7 @@ import os
 from tests.test_amd_desktop.test_amd64_nvme import TestAMD64NVMe as nvm
 
 logger = logging.getLogger(__name__)
-logging.getLogger(__name__).setLevel(logging.DEBUG)
+logging.getLogger(__name__).setLevel(logging.INFO)
 
 class TestRandomReadWrite(nvm):
     ''' Test AMD64 NVM Random Read Write Performance

--- a/tests/test_amd_desktop/test_amd64_stress.py
+++ b/tests/test_amd_desktop/test_amd64_stress.py
@@ -1,0 +1,49 @@
+# Contents of test_amd64_stress.py
+'''Copyright (c) 2024 Jaron Cheng'''
+import logging
+import pytest
+from amd_desktop.amd64_stress import AMD64MultiPathStress as amps
+
+logger = logging.getLogger(__name__)
+logging.getLogger(__name__).setLevel(logging.INFO)
+
+# class TestIOStress8Hours(TestAMD64NVMe):
+class TestIOStress8Hours(object):
+    ''' Test I/O Stress for 8 hours
+        Endurance of the AMD64 system
+        Attributes:
+            os: Operation System
+            manufacturer: Any
+            bdf: Bus-Device-Function in the format of xx:yy.zz
+            sdid: The Sub-device ID of PCIe, confirm SDID of PCI device in advance
+    '''
+    WRITE_PATTERN = 50
+    DURATION = 60
+
+    @pytest.fixture(scope="module", autouse=True)
+    def target_stress(self, target_system):
+        print('\n\033[32m================ Setup I/O Stress ===============\033[0m')
+        return amps(50, 30, target_system.disk_info)
+
+    def test_run_io_operation(self, target_stress, my_mdb):
+        read_bw, read_iops, write_bw, write_iops = target_stress.run_io_operation(
+            1, 32, '4k', '4k', self.WRITE_PATTERN, self.DURATION)
+        
+        logger.info(f'random_read_bw = {read_bw}')
+        logger.info(f'random_read_iops = {read_iops}')
+        logger.info(f'random_write_bw = {write_bw}')
+        logger.info(f'random_write_iops = {write_iops}')
+        
+        # result = my_mdb.aggregate_random_metrics(self.WRITE_PATTERN,
+        #                                         self.QUEUE_DEPTH)
+        # # logger.debug(f'write_pattern = {write_pattern}')
+        # # logger.debug(f'io_depth = {io_depth}')
+        # logger.debug(f'result = {result}')
+
+        # if (result['_id']['write_pattern'] == self.WRITE_PATTERN and
+        #     result['_id']['io_depth'] == self.QUEUE_DEPTH):
+        #     assert read_iops >= result['avg_read_iops'] * 0.9
+        #     assert read_bw >= result['avg_read_bw'] * 0.9
+        #     assert write_iops >= result['avg_write_iops'] * 0.9
+        #     assert write_bw >= result['avg_write_bw'] * 0.9
+

--- a/tests/test_amd_desktop/test_amd64_stress.py
+++ b/tests/test_amd_desktop/test_amd64_stress.py
@@ -27,7 +27,7 @@ class TestIOStress8Hours(object):
 
     def test_run_io_operation(self, target_stress, my_mdb):
         read_bw, read_iops, write_bw, write_iops = target_stress.run_io_operation(
-            1, 32, '4k', '4k', self.WRITE_PATTERN, self.DURATION)
+            2, 32, '4k', '4k', self.WRITE_PATTERN, self.DURATION)
         
         logger.info(f'stress_read_bw = {read_bw}')
         logger.info(f'stress_read_iops = {read_iops}')

--- a/tests/test_amd_desktop/test_amd64_stress.py
+++ b/tests/test_amd_desktop/test_amd64_stress.py
@@ -18,7 +18,7 @@ class TestIOStress8Hours(object):
             sdid: The Sub-device ID of PCIe, confirm SDID of PCI device in advance
     '''
     WRITE_PATTERN = 50
-    DURATION = 60
+    DURATION = 120
 
     @pytest.fixture(scope="module", autouse=True)
     def target_stress(self, target_system):
@@ -29,10 +29,10 @@ class TestIOStress8Hours(object):
         read_bw, read_iops, write_bw, write_iops = target_stress.run_io_operation(
             1, 32, '4k', '4k', self.WRITE_PATTERN, self.DURATION)
         
-        logger.info(f'random_read_bw = {read_bw}')
-        logger.info(f'random_read_iops = {read_iops}')
-        logger.info(f'random_write_bw = {write_bw}')
-        logger.info(f'random_write_iops = {write_iops}')
+        logger.info(f'stress_read_bw = {read_bw}')
+        logger.info(f'stress_read_iops = {read_iops}')
+        logger.info(f'stress_write_bw = {write_bw}')
+        logger.info(f'stress_write_iops = {write_iops}')
         
         # result = my_mdb.aggregate_random_metrics(self.WRITE_PATTERN,
         #                                         self.QUEUE_DEPTH)

--- a/tests/test_unit/test_gpio.py
+++ b/tests/test_unit/test_gpio.py
@@ -27,11 +27,7 @@ class TestOperateGPIO(object):
     def test_press_power_button(self, setup_gpio):
         setup_gpio.press_power_button()
         gpio.output.assert_called()  # 检查 output 方法是否被调用
-        # TODO
-        # Assert power state
 
     def test_hold_power_button(self, setup_gpio):
         setup_gpio.hold_power_button()
         gpio.output.assert_called()  # 检查 output 方法是否被调用
-        # assert 2 == 2
-        # Assert power state


### PR DESCRIPTION
### Pull Request: Add I/O Stress Test for AMD64 Systems

#### Overview

This pull request introduces a new test module, `test_amd64_stress.py`, which is designed to perform I/O stress testing on AMD64 systems. The primary focus of this test is to assess the endurance and performance of the system under prolonged I/O operations.

#### Key Features

- **I/O Stress Testing**:
  - The test is structured to run an I/O operation with a 50% write pattern over a duration of 120 seconds (currently as a placeholder for an 8-hour test).
  - It measures and logs critical performance metrics, including read and write bandwidth (BW) and IOPS, providing insights into the system’s behavior under stress.

- **Targeted System Setup**:
  - The test leverages a fixture to set up the target system for stress testing. This ensures that the test environment is consistently prepared for each run.

- **Modular Design**:
  - The `AMD64MultiPathStress` class from the `amd64_stress.py` module is utilized for the I/O operations, ensuring a modular and reusable approach.

- **Future Enhancements**:
  - The test currently logs the performance metrics but has commented-out sections for potential future enhancements, such as comparing the measured IOPS and BW against aggregated random metrics from a database.

#### Why This Is Important

This test is crucial for validating the durability and performance of AMD64 systems in scenarios where sustained I/O activity is critical. By identifying potential performance bottlenecks or failures under stress, we can ensure that these systems meet the required reliability and endurance standards.

#### Next Steps

- **Extend the Duration**: The test is currently configured for 120 seconds for initial validation. The duration should be extended to the full 8 hours to thoroughly assess endurance.
- **Metric Comparison**: Uncomment and refine the sections for comparing the test results against database metrics to automatically validate performance thresholds.

#### How to Test

- Run the test module `test_amd64_stress.py` using `pytest`.
- Observe the logged outputs for read and write IOPS and bandwidth.
- Verify that the system remains stable throughout the test duration.

#### Notes

This pull request does not include automated comparison against historical performance data; this feature can be added in a future iteration.